### PR TITLE
Set default libmain.so URL in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
       libmain_so_url:
         description: 'libmain.so Patch URL'
         required: true
-        default: ''
+        default: 'https://github.com/kairusds/Hachimi-Edge/releases/latest/download/libmain-arm64-v8a.so'
       keystore_url:
         description: 'Debug keystore URL'
         required: true


### PR DESCRIPTION
Updated default URL for libmain.so in build workflow.
(always use latest releases from kairusds)